### PR TITLE
Close #2: Highcharts metrics dashboard on Projects index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,7 +3,12 @@ class ProjectsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-  	@projects = Project.all.order("created_at DESC")
+    @projects = Project.all.order("created_at DESC")
+
+    # Basic metrics for visualization.
+    @projects_by_department = Project.group(:department).count
+    @projects_by_test_type = Project.group(:test_type).count
+    @cost_by_department = Project.group(:department).average(:cost)
   end
 
   def show

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,19 +6,22 @@
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
-    %link{ rel: "stylesheet", href: "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" }
-    %link{ rel: "stylesheet", href: "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css", integrity: "sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN", crossorigin: "anonymous" }
+    %link{:rel => "stylesheet", :href => "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css"}
+    %link{:rel => "stylesheet", :href => "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css", :integrity => "sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN", :crossorigin => "anonymous"}
+
+    / Highcharts (metrics visualization)
+    %script{:src => "https://code.highcharts.com/highcharts.js"}
 
   %body
-    %script{ src: "https://code.jquery.com/jquery-3.1.1.slim.min.js", integrity: "sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n", crossorigin: "anonymous" }
-    %script{ src: "https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js", integrity: "sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb", crossorigin: "anonymous" }
-    %script{ src: "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js", integrity: "sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn", crossorigin: "anonymous" }
+    %script{:src => "https://code.jquery.com/jquery-3.1.1.slim.min.js", :integrity => "sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n", :crossorigin => "anonymous"}
+    %script{:src => "https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js", :integrity => "sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb", :crossorigin => "anonymous"}
+    %script{:src => "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js", :integrity => "sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn", :crossorigin => "anonymous"}
 
     %nav.navbar.navbar-toggleable-md.navbar-light.bg-faded
       .container
         = link_to "Security Testing Dashboard", root_path, class: "navbar-brand"
 
-        %button.navbar-toggler.navbar-toggler-right{ type: "button", data: { toggle: "collapse", target: "#navbarNav" }, aria: { controls: "navbarNav", expanded: "false", label: "Toggle navigation" } }
+        %button.navbar-toggler.navbar-toggler-right{"type" => "button", "data-toggle" => "collapse", "data-target" => "#navbarNav", "aria-controls" => "navbarNav", "aria-expanded" => "false", "aria-label" => "Toggle navigation"}
           %span.navbar-toggler-icon
 
         #navbarNav.collapse.navbar-collapse

--- a/app/views/projects/_metrics.html.haml
+++ b/app/views/projects/_metrics.html.haml
@@ -1,0 +1,57 @@
+-# Metrics visualization for Projects
+-# Uses instance vars set in ProjectsController#index.
+
+.row
+  .col-md-6
+    %h3 Projects by Department
+    %div{:id => "department-chart", :style => "height: 320px;"}
+
+  .col-md-6
+    %h3 Projects by Test Type
+    %div{:id => "testtype-chart", :style => "height: 320px;"}
+
+.row.mt-4
+  .col-md-12
+    %h3 Average Cost by Department
+    %div{:id => "avgcost-chart", :style => "height: 320px;"}
+
+:javascript
+  document.addEventListener('DOMContentLoaded', function () {
+    var projectsByDepartment = #{(@projects_by_department || {}).to_json};
+    var projectsByTestType = #{(@projects_by_test_type || {}).to_json};
+    var avgCostByDepartment = #{(@cost_by_department || {}).transform_values { |v| v&.to_f }.to_json};
+
+    function objectToSeries(obj) {
+      return Object.keys(obj).map(function (k) {
+        return { name: (k && k.length ? k : '(none)'), y: obj[k] };
+      });
+    }
+
+    Highcharts.chart('department-chart', {
+      chart: { type: 'column' },
+      title: { text: null },
+      xAxis: { type: 'category' },
+      yAxis: { title: { text: 'Projects' }, allowDecimals: false },
+      legend: { enabled: false },
+      series: [{ name: 'Projects', data: objectToSeries(projectsByDepartment) }]
+    });
+
+    Highcharts.chart('testtype-chart', {
+      chart: { type: 'bar' },
+      title: { text: null },
+      xAxis: { type: 'category' },
+      yAxis: { title: { text: 'Projects' }, allowDecimals: false },
+      legend: { enabled: false },
+      series: [{ name: 'Projects', data: objectToSeries(projectsByTestType) }]
+    });
+
+    Highcharts.chart('avgcost-chart', {
+      chart: { type: 'line' },
+      title: { text: null },
+      xAxis: { type: 'category' },
+      yAxis: { title: { text: 'Avg Cost' } },
+      legend: { enabled: false },
+      tooltip: { valueDecimals: 2 },
+      series: [{ name: 'Avg Cost', data: objectToSeries(avgCostByDepartment) }]
+    });
+  });

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,4 +1,9 @@
-%h1 Placeholder title
+%h1 Projects
+
+= render 'metrics'
+
+%hr
+
 - @projects.each do |project|
   %h2= link_to project.title, project
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
 class ProjectsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "index renders metrics containers" do
+    get root_url
+    assert_response :success
+
+    assert_includes @response.body, "department-chart"
+    assert_includes @response.body, "testtype-chart"
+    assert_includes @response.body, "avgcost-chart"
+  end
 end

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,23 +1,25 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
-  link: MyString
-  description: MyText
-  cost: 1
-  type: 
-  tester: MyString
-  rp: MyString
-  architect: MyString
-  department: MyString
+  title: Project One
+  link: https://example.com/one
+  description: Example project
+  cost: 100
+  test_type: SAST
+  tester: Alice
+  rp: Bob
+  architect: Carol
+  department: AppSec
+  user: one
 
 two:
-  title: MyString
-  link: MyString
-  description: MyText
-  cost: 1
-  type: 
-  tester: MyString
-  rp: MyString
-  architect: MyString
-  department: MyString
+  title: Project Two
+  link: https://example.com/two
+  description: Another example project
+  cost: 200
+  test_type: DAST
+  tester: Dave
+  rp: Erin
+  architect: Frank
+  department: Platform
+  user: one

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,9 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+one:
+  email: one@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password123') %>
+  name: User One
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+two:
+  email: two@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password123') %>
+  name: User Two


### PR DESCRIPTION
Closes #2.

### What changed
- Added **Highcharts** via CDN in the application layout.
- Projects index now renders a small metrics dashboard:
  - Projects by Department (column)
  - Projects by Test Type (bar)
  - Average Cost by Department (line)
-  now precomputes grouped aggregates used by the charts.

### Tests
- Added an integration test to assert metrics containers render on the index page:
  - Run options: --seed 24958

# Running:

.

Finished in 0.795315s, 1.2574 runs/s, 8.8015 assertions/s.
1 runs, 7 assertions, 0 failures, 0 errors, 0 skips

### Notes
- Updated fixtures (, ) to reflect the current schema (uses , adds  association).
- Updated  to ignore  if bundler is run with .
